### PR TITLE
Command add Run method

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-
 	"github.com/asim/go-micro/v3/auth"
 	"github.com/asim/go-micro/v3/broker"
 	"github.com/asim/go-micro/v3/cache"
@@ -224,5 +223,19 @@ func NewTracer(name string, t func(...trace.Option) trace.Tracer) Option {
 func NewAuth(name string, t func(...auth.Option) auth.Auth) Option {
 	return func(o *Options) {
 		o.Auths[name] = t
+	}
+}
+
+// New config func
+func NewConfig(name string, t func(...config.Option) (config.Config, error)) Option  {
+	return func(o *Options) {
+		o.Configs[name] = t
+	}
+}
+
+// New profile func
+func NewProfile(name string, t func(...profile.Option) profile.Profile) Option {
+	return func(o *Options) {
+		o.Profiles[name] = t
 	}
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	
 	"github.com/asim/go-micro/v3/auth"
 	"github.com/asim/go-micro/v3/broker"
 	"github.com/asim/go-micro/v3/cache"


### PR DESCRIPTION
**background:**
When I tried to increase the built-in config option, I found that I must increase before cmd.init, because when I execute service.init, execute cmd.init before executing service.init will cause cmd.init Repeat execution.

Of course, I can prioritize the options option in the newcmd (options) method, but this will cause another problem, I can't get the current CMD INSTANCE inside Options, as shown below:
```go
	c := cmd2.NewCmd(
		cmd2.NewConfig(`consul`, func(option ...config.Option) (config.Config, error) {
			// like this
			// I hope to get c var instance
			// but at this time, I am initializing me.
			return config.NewConfig(option...)
		}),
		cmd2.NewConfig(`file`, func(option ...config.Option) (config.Config, error) {
			return config.NewConfig(option...)
		}),
	)

	// execute init method

	c.Init()

	// Will execute cmd.init again
	service.Init()
```
I think this may be unreasonable, I have changed this option.

This may cause incompatibility under scenes that do not use Defaultcmd, but I think this still needs to be updated.